### PR TITLE
Pass className for styled component support

### DIFF
--- a/src/components/CookieBanner.js
+++ b/src/components/CookieBanner.js
@@ -181,6 +181,7 @@ class CookieBanner extends React.Component {
 
     const contentProps = {
       styles,
+      className: this.props.className,
       message,
       policyLink,
       privacyPolicyLinkText,
@@ -206,6 +207,7 @@ class CookieBanner extends React.Component {
 }
 
 CookieBanner.protoTypes = {
+  className: PropTypes.string,
   styles: PropTypes.object,
   message: PropTypes.string.isRequired,
   policyLink: PropTypes.string,

--- a/src/components/CookieBanner.spec.js
+++ b/src/components/CookieBanner.spec.js
@@ -30,6 +30,15 @@ describe('CookieBanner component', () => {
     expect(component.find(CookieBannerContent)).toHaveLength(1);
   });
 
+
+  test('should be rendered with custom class', () => {
+    const component = mount(
+      <CookieBanner className={'testclass'} message="Custom text" />,
+    );
+
+    expect(component.hasClass('testclass')).toBe(true)
+  });
+
   test('shouldn\'t show banner if cookies are already accepted', () => {
     document.cookie = 'rcl_consent_given=true';
 

--- a/src/components/CookieBannerContent.js
+++ b/src/components/CookieBannerContent.js
@@ -5,6 +5,7 @@ import bannerStyle from './bannerStyle';
 export default (props = {}) => {
   const {
     styles = {},
+    className,
     message = 'No text',
     policyLink = '/#',
     privacyPolicyLinkText = 'Privacy Policy',
@@ -41,7 +42,7 @@ export default (props = {}) => {
   const cookieOptionStyle = { optionWrapperStyle, optionLabelStyle, checkboxStyle };
 
   return (
-    <div className="react-cookie-law-dialog" style={dialogStyle}>
+    <div className={`react-cookie-law-dialog ${className}`}  style={dialogStyle}>
       <div className="react-cookie-law-container" style={containerStyle}>
         <div className="react-cookie-law-msg" style={messageStyle}>{message}</div>
 


### PR DESCRIPTION
Allow a className to pass into the Cookiebanner component, so that it can (also) be styled with styled components.