### PR TITLE
Fix #16 - add support for root domain path in cookies and prevent CookieBanner to show up on every page even if already set

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ React.renderComponent(
   <div>
     <CookieBanner
       message="Cookie banner message"
+      wholeDomain={true}
       onAccept = {() => {}}
       onAcceptPreferences = {() => {}}
       onAcceptStatistics = {() => {}}
@@ -43,6 +44,7 @@ React.renderComponent(
 |----|----|-------|-----------|
 | **className** | string | | **optional**. Classes |
 | **message** | string | | **Required**. Custom text of the banner |
+| **wholeDomain** | bool | false | *optional*. Enable or disable the root path '/' option when a cookie is set |
 | **policyLink** | string | "/#" | *optional*. Link to privacy policy page |
 | **privacyPolicyLinkText** | string | "Privacy Policy" | *optional*. Text for the privacy policy link |
 | **necessaryOptionText** | string | "Necessary" | *optional*. Text for the *necessary* cookies checkbox |

--- a/src/Cookies.js
+++ b/src/Cookies.js
@@ -2,8 +2,9 @@ import { Cookies as ReactCookies } from 'react-cookie';
 import { getExpirationDate } from './helpers';
 
 export default class Cookies {
-  constructor() {
+  constructor(wholeDomain=false) {
     this.cookies = new ReactCookies();
+    this.whole_domain = wholeDomain;
   }
 
   get(cookie) {
@@ -11,8 +12,10 @@ export default class Cookies {
   }
 
   set(cookie, cookieExpiration) {
+    const optionPath = this.whole_domain ? { path: '/' } : {};
     this.cookies.set(cookie, true, {
       expires: cookieExpiration || getExpirationDate(),
+      ...{optionPath}
     });
   }
 

--- a/src/components/CookieBanner.js
+++ b/src/components/CookieBanner.js
@@ -27,7 +27,7 @@ class CookieBanner extends React.Component {
     this.decline = this.decline.bind(this);
     this.consetsCallback = this.consetsCallback.bind(this);
 
-    this.cookies = new Cookies();
+    this.cookies = new Cookies(this.props.wholeDomain);
   }
 
   componentDidMount() {
@@ -211,6 +211,7 @@ CookieBanner.protoTypes = {
   className: PropTypes.string,
   styles: PropTypes.object,
   message: PropTypes.string.isRequired,
+  wholeDomain: PropTypes.bool,
   policyLink: PropTypes.string,
   privacyPolicyLinkText: PropTypes.string,
   necessaryOptionText: PropTypes.string,


### PR DESCRIPTION
With only 2 lines changes and 4 additional lines of code I added a fix to (optionally) set the cookies on the whole domain adding an option to the Cookie.js file as described in #16 

Someone is able to give me a hint if this changes can be approved? 

Hoping this PR will be merged soon I'll wish you a good evening.

:clinking_glasses: 