### PR TITLE
fix: callbacks are called on every page load (fixes issue #31)

### DIFF
--- a/src/components/CookieBanner.js
+++ b/src/components/CookieBanner.js
@@ -81,20 +81,12 @@ class CookieBanner extends React.Component {
   }
 
   onAcceptAll() {
-    const {
-      onAcceptPreferences = () => {},
-      onAcceptStatistics = () => {},
-      onAcceptMarketing = () => {},
-    } = this.props;
-
     this.cookies.set(CONSENT_GIVEN);
     this.cookies.set(PREFERENCES_COOKIE);
     this.cookies.set(STATISTICS_COOKIE);
     this.cookies.set(MARKETING_COOKIE);
 
-    onAcceptPreferences();
-    onAcceptStatistics();
-    onAcceptMarketing();
+    this.consetsCallback();
 
     this.forceUpdate();
   }
@@ -121,6 +113,8 @@ class CookieBanner extends React.Component {
     } else {
       this.cookies.remove(MARKETING_COOKIE);
     }
+
+    this.consetsCallback();
 
     this.forceUpdate();
   }
@@ -205,7 +199,6 @@ class CookieBanner extends React.Component {
     } = this.props;
 
     if (this.cookies.get(CONSENT_GIVEN)) {
-      this.consetsCallback();
       return null;
     }
 


### PR DESCRIPTION
Removes call to consetsCallback() on every page load. Now it is called only when user press 'accept all' button or 'save preferences' button. Fixes issue #31.