### PR TITLE
fix: wholeDomain option now set cookies in '/' (fixes #33)

### DIFF
--- a/src/Cookies.js
+++ b/src/Cookies.js
@@ -15,7 +15,7 @@ export default class Cookies {
     const optionPath = this.whole_domain ? { path: '/' } : {};
     this.cookies.set(cookie, true, {
       expires: cookieExpiration || getExpirationDate(),
-      ...{ optionPath },
+      ... optionPath,
     });
   }
 


### PR DESCRIPTION
Fixes bug causing that the option wholeDomain was not working when set to true. Fixes issue #33