### PR TITLE
Changing "mange" to "manage"

### DIFF
--- a/src/components/CookieBannerContent.js
+++ b/src/components/CookieBannerContent.js
@@ -17,7 +17,7 @@ class CookieBannerContent extends React.Component {
       policyLink = '/#',
       privacyPolicyLinkText = 'Privacy Policy',
       acceptButtonText = 'Accept all',
-      managePreferencesButtonText = 'Mange my cookies',
+      managePreferencesButtonText = 'Manage my cookies',
       savePreferencesButtonText = 'Save and close',
       onConfirm = () => {},
       onAcceptAll = () => {},

--- a/src/components/CookieBannerContent.spec.js
+++ b/src/components/CookieBannerContent.spec.js
@@ -24,7 +24,7 @@ describe('CookieBannerContent component', () => {
       statisticsOptionText: 'Statistics',
       marketingOptionText: 'Marketing',
       acceptButtonText: 'Accept all',
-      managePreferencesButtonText: 'Mange my cookies',
+      managePreferencesButtonText: 'Manage my cookies',
       savePreferencesButtonText: 'Save and close',
     };
 

--- a/src/components/__snapshots__/CookieBannerContent.spec.js.snap
+++ b/src/components/__snapshots__/CookieBannerContent.spec.js.snap
@@ -86,7 +86,7 @@ exports[`CookieBannerContent component should be rendered 1`] = `
         type="button"
       >
         <span>
-          Mange my cookies
+          Manage my cookies
         </span>
       </button>
       <button


### PR DESCRIPTION
I was hoping the default text could be changed from "Mange my cookies" (such a clever pun) to "Manage my cookies".